### PR TITLE
Fix tags looking weird in replies

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,7 @@
 .stafftags {
   font-weight: 500 !important;
 }
+
+div[class*="repliedMessage-"] .stafftags {
+  margin-right: .25rem;
+}


### PR DESCRIPTION
This addresses issue #5 by adding a border-right to all stafftags that are in the reply part of a message. This broder-right has the same width as the border-left, making it fit in smoothly.
Closes #5 