### PR TITLE
[Fix] Staff tags did not have a margin in thread message accessories

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2,6 +2,7 @@
   font-weight: 500 !important;
 }
 
-div[class*="repliedMessage-"] .stafftags {
+div[class*="repliedMessage-"] .stafftags,
+div[class*="threadMessageAccessory-"] .stafftags {
   margin-right: .25rem;
 }


### PR DESCRIPTION
This Closes #7 by adding a border-right to all stafftags that are in the thread accessory of a message, similar to #6.