### PR TITLE
right after username

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -118,7 +118,7 @@ export async function start(): Promise<void> {
                 />
               </ErrorBoundary>
             );
-            res.props.children.push(a);
+            res.props.children.unshift(a);
           }
           return res;
         },


### PR DESCRIPTION
make the crown appear right after username instead of after other tags like nitro bot or platform indicator