### PR TITLE
Fix tags looking weird in replies (Typo)

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -3,7 +3,7 @@
   margin: 1px 0 0 4px !important;
 }
 
-div[class*="repliedMessage-"] .stafftags,
-div[class*="threadMessageAccessory-"] .stafftags {
+div[class*="repliedMessage-"] .stafftag,
+div[class*="threadMessageAccessory-"] .stafftag {
   margin-right: 0.25rem;
 }


### PR DESCRIPTION
The newest update reintroduced a bug because a class was renamed. This PR fixes a typo.