### PR TITLE
Fix the previous typo fix

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -5,5 +5,5 @@
 
 div[class*="repliedMessage-"] .stafftag,
 div[class*="threadMessageAccessory-"] .stafftag {
-  margin-right: 0.25rem;
+  margin-right: 0.25rem !important;
 }


### PR DESCRIPTION
It turns out that since !important was added on a border: style attribute in the same file, that the border-right did not apply anymore. This very small PR fixes it.
Sorry for the small incremental pull requests.